### PR TITLE
Temporarily pin Nixpkgs to a known-working commit.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
 let
-  pkgs = import (builtins.fetchTarball "channel:nixos-unstable-small") {};
+  # Temporarily pin Nixpkgs: https://github.com/NixOS/nixpkgs/pull/126993#issuecomment-884192962
+  pkgs = import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/578dd8d634f0a4666f7481f6ea9e578114da74f8.tar.gz") { };
 
   perl = pkgs.perl.withPackages (ps: with ps; [ JSON DateTime HTMLTidy ]);
 in


### PR DESCRIPTION
This is prior to the latest staging merge, causing a regression in tidyp.